### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -91,12 +91,12 @@ work on old linux kernels while writing to an NFS.
    :target: https://ci.appveyor.com/project/musically-ut/seqfile
 .. |Coverage| image:: https://coveralls.io/repos/musically-ut/seqfile/badge.svg?branch=master
    :target: https://coveralls.io/r/musically-ut/seqfile?branch=master
-.. |PythonVersions| image:: https://pypip.in/py_versions/seqfile/badge.svg
+.. |PythonVersions| image:: https://img.shields.io/pypi/pyversions/seqfile.svg
    :target: https://pypi.python.org/pypi/seqfile/
    :alt: Supported Python versions
-.. |PyPiVersion| image:: https://pypip.in/version/seqfile/badge.svg
+.. |PyPiVersion| image:: https://img.shields.io/pypi/v/seqfile.svg
    :target: https://pypi.python.org/pypi/seqfile/
    :alt: Latest Version
-.. |License| image:: https://pypip.in/license/seqfile/badge.svg
+.. |License| image:: https://img.shields.io/pypi/l/seqfile.svg
    :target: https://pypi.python.org/pypi/seqfile/
    :alt: License


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20seqfile))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `seqfile`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.